### PR TITLE
Generate random twitter referrers

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,15 @@
+// Looks like medium is blocking requests the with specific Referrer header value: https://t.co/JV5396gd2O
+// In order to bypass this, generate "random" header values
+// Pick a random number between 1 and 2
+// Convert to Base 36 (so it should be alphanumeric)
+// Get first 10 characters after decimal
+function generateReferrer() {
+  var linkId = (1 + Math.random()).toString(36).substring(2, 12);
+  return `https://t.co/${linkId}`;
+}
+
 chrome.webRequest.onBeforeSendHeaders.addListener(function(details){
-  var newRef = "https://t.co/JV5396gd2O";
+  var newRef = generateReferrer();
   var gotRef = false;
   for(var n in details.requestHeaders){
     gotRef = details.requestHeaders[n].name.toLowerCase()=="referer";

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -1,8 +1,19 @@
+// Looks like medium is blocking requests the with specific Referrer header value: https://t.co/JV5396gd2O
+// In order to bypass this, generate "random" header values
+// Pick a random number between 1 and 2
+// Convert to Base 36 (so it should be alphanumeric)
+// Get first 10 characters after decimal
+function generateReferrer() {
+  var linkId = (1 + Math.random()).toString(36).substring(2, 12);
+  return `https://t.co/${linkId}`;
+}}
+
 var app = {};
+
 // Modify the referer to bypass Medium's paywall.
 app.modifyHeaders = function(details) {
   // The link is pointed to `medium.com` redirected through a twitter url.
-  var newRef = "https://t.co/JV5396gd2O";
+  var newRef = generateReferrer();
   var gotRef = false;
   for (var n in details.requestHeaders) {
     gotRef = details.requestHeaders[n].name.toLowerCase() == "referer";


### PR DESCRIPTION
Resolves #9 and #10 by generating "random" referrer URLs. 

It looks like Medium is blocking requests with the `Referrer` header value set to `https://t.co/JV5396gd2O` but other requests with a `t.co` `Referrer` header value seem to be valid.

One way to bypass this is to vary the `Referrer` header value.

I implemented a "random" `Referrer` generator which basically copies [this StackOverflow answer](https://stackoverflow.com/a/8084248/10039741).