### PR TITLE
Add's a few more custom domain URLs that the extension does not currently work on

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -61,6 +61,13 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
       '*://extranewsfeed.com/*',
       '*://democracyguardian.com/*',
       '*://*.issuevoter.org/*',
+      '*://betterprogramming.pub/*',
+      '*://500ish.com/*',
+      '*://blog.bitsrc.io/*',
+      '*://blog.expo.dev/*',
+      '*://*.plainenglish.io/*',
+      '*://blog.sessionstack.com/*',
+      '*://lambda.grofers.com/*',
     ]
   },
   [

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Mediumship",
-    "version": "2.7",
+    "version": "2.8",
     "description": "Read all Medium stories for free.",
     "background": {
         "scripts": [

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -61,6 +61,13 @@ browser.webRequest.onBeforeSendHeaders.addListener(
       '*://extranewsfeed.com/*',
       '*://democracyguardian.com/*',
       '*://*.issuevoter.org/*',
+      '*://betterprogramming.pub/*',
+      '*://500ish.com/*',
+      '*://blog.bitsrc.io/*',
+      '*://blog.expo.dev/*',
+      '*://*.plainenglish.io/*',
+      '*://blog.sessionstack.com/*',
+      '*://lambda.grofers.com/*',
     ]
   },
   [

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Mediumship",
-    "version": "2.7",
+    "version": "2.8",
     "description": "Read all Medium stories for free.",
     "background": {
         "scripts": [


### PR DESCRIPTION
Websites added in this PR:
```
      '*://betterprogramming.pub/*',
      '*://500ish.com/*',
      '*://blog.bitsrc.io/*',
      '*://blog.expo.dev/*',
      '*://*.plainenglish.io/*',
      '*://blog.sessionstack.com/*',
      '*://lambda.grofers.com/*',
 ```